### PR TITLE
Update default request parameters to enhance filtering functionality

### DIFF
--- a/src/app/(authenticated)/requests/page.tsx
+++ b/src/app/(authenticated)/requests/page.tsx
@@ -27,9 +27,9 @@ import DataTableRequestsSkeleton from './DataTableRequests/skeleton';
 import { PaginationDemo } from '@/components/PaginationDemo';
 
 const defaultValues: UseGetRequestsParams = {
-  from: new Date(new Date().setHours(0, 0, 0, 0)).toISOString(),
+  from: new Date(new Date().setDate(new Date().getDate() - 14)).toISOString(),
   to: new Date(new Date().setHours(23, 59, 59, 999)).toISOString(),
-  status: null,
+  status: 'Pending',
   category: null,
   clientId: null,
   companyId: null,


### PR DESCRIPTION
- Changed the default 'from' date to 14 days prior for improved request history visibility.
- Updated the default 'status' to 'Pending' to streamline initial request filtering.