### PR TITLE
Update filterCleaningMustHavePhotos logic for Free Plan users

### DIFF
--- a/src/app/(authenticated)/settings/companies/team/[id]/Preferences.tsx
+++ b/src/app/(authenticated)/settings/companies/team/[id]/Preferences.tsx
@@ -89,7 +89,9 @@ export default function Page({ company }: { company: Company }) {
       sendSkippedServiceEmails: company.preferences?.serviceEmailPreferences?.sendSkippedServiceEmails || false,
       filterCleaningIntervalDays: company.preferences?.equipmentMaintenancePreferences?.filterCleaningIntervalDays || 28,
       filterReplacementIntervalDays: company.preferences?.equipmentMaintenancePreferences?.filterReplacementIntervalDays || 365,
-      filterCleaningMustHavePhotos: company.preferences?.equipmentMaintenancePreferences?.filterCleaningMustHavePhotos || false,
+      filterCleaningMustHavePhotos: isFreePlan
+        ? false
+        : company.preferences?.equipmentMaintenancePreferences?.filterCleaningMustHavePhotos || false,
       sendFilterCleaningEmails: isFreePlan ? false : company.preferences?.serviceEmailPreferences?.sendFilterCleaningEmails || false,
 
       // New fields
@@ -223,7 +225,9 @@ export default function Page({ company }: { company: Company }) {
       case 'filterReplacementIntervalDays':
         return company.preferences?.equipmentMaintenancePreferences?.filterReplacementIntervalDays || 365;
       case 'filterCleaningMustHavePhotos':
-        return company.preferences?.equipmentMaintenancePreferences?.filterCleaningMustHavePhotos || false;
+        return isFreePlan
+          ? false
+          : company.preferences?.equipmentMaintenancePreferences?.filterCleaningMustHavePhotos || false;
       case 'sendFilterCleaningEmails':
         return isFreePlan ? false : company.preferences?.serviceEmailPreferences?.sendFilterCleaningEmails || false;
       case 'allowAnticipatedServices':
@@ -311,7 +315,7 @@ export default function Page({ company }: { company: Company }) {
       equipmentMaintenancePreferences: {
         filterCleaningIntervalDays: Number(filterCleaningIntervalDays),
         filterReplacementIntervalDays: Number(filterReplacementIntervalDays),
-        filterCleaningMustHavePhotos
+        filterCleaningMustHavePhotos: isFreePlan ? false : filterCleaningMustHavePhotos
       },
       serviceEmailPreferences: {
         sendEmails,

--- a/src/app/(authenticated)/settings/companies/team/[id]/components/FilterMaintenanceCard/FilterMaintenanceCard.tsx
+++ b/src/app/(authenticated)/settings/companies/team/[id]/components/FilterMaintenanceCard/FilterMaintenanceCard.tsx
@@ -55,6 +55,7 @@ const filterFields = [
     itens: [
       {
         label: 'Require photo to every filter cleaned or replaced',
+        subLabel: '(only on grow plan)',
         description: 'Technicians must take photos when cleaning or replacing filters',
         name: 'filterCleaningMustHavePhotos'
       }
@@ -134,13 +135,15 @@ export function FilterMaintenanceCard({
                 </div>
                 <div className="col-span-4 flex flex-col gap-2">
                   {field.itens.map((item) => {
-                    const isFilterEmailField = item.name === 'sendFilterCleaningEmails';
+                    const isGrowOnlyField =
+                      item.name === 'sendFilterCleaningEmails' ||
+                      item.name === 'filterCleaningMustHavePhotos';
 
                     return (
                       <div key={item.name} className="flex w-full items-center gap-4">
                         <div className={field.type === FieldType.Default ? 'w-full' : ''}>
                           <InputField
-                            disabled={isFilterEmailField && isFreePlan}
+                            disabled={isFreePlan && isGrowOnlyField}
                             name={item.name}
                             type={'type' in item ? item.type : field.type}
                             placeholder={field.type === FieldType.Default ? item.label : ''}


### PR DESCRIPTION
- Adjusted the logic for the filterCleaningMustHavePhotos preference to default to false for Free Plan users.
- Updated the FilterMaintenanceCard component to include a subLabel indicating that the photo requirement applies only to Grow Plan users.
- Ensured consistent handling of preferences related to filter cleaning emails based on the user's plan.